### PR TITLE
Added field 'featured' to exhibits

### DIFF
--- a/API_DOCS.md
+++ b/API_DOCS.md
@@ -149,6 +149,7 @@ You can also filter by several things. All of these parameters are optional:
         description: string // its description
         image: integer // the ID of the actual image
       }
+      featured: boolean // if the exhibit is featured by the staff at Comic-Con
       supporters: integer // How many people have supported the exhibit
       // requires login:
       isSupported: boolean // Whether or not the current user supports it
@@ -181,6 +182,7 @@ returns a 404.
   supporters: integer // How many people have supported the exhibit
   author: string // The username of the creator of the exhibit
   created: datetime // When the exhibit was created
+  featured: boolean // if the exhibit is featured by the staff at Comic-Con
   tags: [ string ] // The tags of the exhibit
   artifacts: [ // The artifacts associated with this exhibit
     {
@@ -578,6 +580,34 @@ Get all of the survey data for a given exhibit.
 ### Authorization
 
 You must be authorized as an admin to hit this endpoint.
+
+
+## `POST /admin/feature/{id}`
+
+Marks an exhibit as featured.
+If the exhibit is already featured, this will have no effect.
+
+### Authorization
+
+You must be authorized as an admin to hit this endpoint.
+
+### Response
+ - 204 if the exhibit exists and you are an admin
+ - 404 if the exhibit does not exist
+
+
+## `DELETE /admin/feature/{id}`
+
+Un-marks an exhibit as featured.
+If the exhibit is already not featured, this will have no effect.
+
+### Authorization
+
+You must be authorized as an admin to hit this endpoint.
+
+### Response
+ - 204 if the exhibit exists and you are an admin
+ - 404 if the exhibit does not exist
 
 ## `GET /image/{id}`
 

--- a/API_DOCS.md
+++ b/API_DOCS.md
@@ -591,10 +591,6 @@ If the exhibit is already featured, this will have no effect.
 
 You must be authorized as an admin to hit this endpoint.
 
-### Response
- - 204 if the exhibit exists and you are an admin
- - 404 if the exhibit does not exist
-
 
 ## `DELETE /admin/feature/{id}`
 
@@ -605,9 +601,6 @@ If the exhibit is already not featured, this will have no effect.
 
 You must be authorized as an admin to hit this endpoint.
 
-### Response
- - 204 if the exhibit exists and you are an admin
- - 404 if the exhibit does not exist
 
 ## `GET /image/{id}`
 

--- a/src/main/java/org/comic_conmuseum/fan_forge/backend/Application.java
+++ b/src/main/java/org/comic_conmuseum/fan_forge/backend/Application.java
@@ -108,8 +108,8 @@ public class Application implements CommandLineRunner {
                     null, false
             ), original);
 
-            // exhibit 1 is featured
-            if (exhibitId == 1) {
+            // exhibit 1 and 11 are featured
+            if (exhibitId % 10 == 1) {
                 exhibits.markFeatured(exhibitId);
             }
 

--- a/src/main/java/org/comic_conmuseum/fan_forge/backend/Application.java
+++ b/src/main/java/org/comic_conmuseum/fan_forge/backend/Application.java
@@ -101,11 +101,18 @@ public class Application implements CommandLineRunner {
         for (int eIdx = 0; eIdx < exhibitTitles.size(); ++eIdx) {
             String title = exhibitTitles.get(eIdx);
             Instant exhibitMade = Instant.now().minus(eIdx + 5, ChronoUnit.DAYS);
+            // tags are based on even/odd indexes
             long exhibitId = exhibits.create(new Exhibit(
                     0, title, "Description for " + title, original.getId(),
                     exhibitMade, new String[] { "post", "exhibit", eIdx % 2 == 0 ? "even" : "odd", "index:" + eIdx },
-                    null
+                    null, false
             ), original);
+
+            // exhibit 1 is featured
+            if (exhibitId == 1) {
+                exhibits.markFeatured(exhibitId);
+            }
+
             for (int sIdx = 0; sIdx < supporters.length; ++sIdx) {
                 if ((eIdx & sIdx) == sIdx) {
                     supports.createSupport(

--- a/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/ExhibitEndpoints.java
+++ b/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/ExhibitEndpoints.java
@@ -182,4 +182,16 @@ public class ExhibitEndpoints {
         List<String> results = exhibits.getAllTags();
         return ResponseEntity.ok(results);
     }
+
+    @RequestMapping(value = "/admin/feature/{id}", method = RequestMethod.POST)
+    public ResponseEntity createFeatured(@PathVariable long id) { // auth handled by WebSecurityConfig
+        boolean found = exhibits.markFeatured(id);
+        return found ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+
+    @RequestMapping(value = "/admin/feature/{id}", method = RequestMethod.DELETE)
+    public ResponseEntity deleteFeatured(@PathVariable long id) { // auth handled by WebSecurityConfig
+        boolean found = exhibits.deleteFeatured(id);
+        return found ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
 }

--- a/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/inputs/ExhibitCreation.java
+++ b/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/inputs/ExhibitCreation.java
@@ -29,6 +29,6 @@ public class ExhibitCreation {
     public Exhibit build(User author) {
         // We don't do any validation in here because different endpoints have
         // different requirements, so each one implements its own.
-        return new Exhibit(-1, this.title, this.description, author.getId(), Instant.now(), this.tags, null);
+        return new Exhibit(-1, this.title, this.description, author.getId(), Instant.now(), this.tags, null, false);
     }
 }

--- a/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/responses/ExhibitFull.java
+++ b/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/responses/ExhibitFull.java
@@ -29,7 +29,7 @@ public class ExhibitFull extends Feed.Entry {
     public final String[] tags;
     public final List<Image> artifacts;
     public final List<CommentView> comments;
-    
+
     // hide the parent's cover
     @SuppressWarnings("unused") @JsonIgnore public final Object cover = null;
     

--- a/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/responses/Feed.java
+++ b/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/responses/Feed.java
@@ -41,7 +41,7 @@ public class Feed {
             this.supporters = supporters;
             this.supported = supported;
             this.comments = comments;
-            this.featured = of.getFeatured();
+            this.featured = of.isFeatured();
         }
     }
     

--- a/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/responses/Feed.java
+++ b/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/responses/Feed.java
@@ -31,6 +31,7 @@ public class Feed {
         public final long comments;
         @JsonInclude(JsonInclude.Include.NON_NULL)
         public final Boolean supported;
+        public final boolean featured;
         
         public Entry(Exhibit of, long supporters, long comments, Boolean supported) {
             this.id = of.getId();
@@ -40,6 +41,7 @@ public class Feed {
             this.supporters = supporters;
             this.supported = supported;
             this.comments = comments;
+            this.featured = of.getFeatured();
         }
     }
     

--- a/src/main/java/org/comic_conmuseum/fan_forge/backend/models/Exhibit.java
+++ b/src/main/java/org/comic_conmuseum/fan_forge/backend/models/Exhibit.java
@@ -12,9 +12,10 @@ public class Exhibit {
     private Instant created;
     private String[] tags;
     private Artifact cover;
+    private boolean featured;
 
     public Exhibit(long eid, String title, String description, String author,
-                   Instant created, String[] tags, Artifact cover) {
+                   Instant created, String[] tags, Artifact cover, boolean featured) {
         this.id = eid;
         this.title = title;
         this.description = description;
@@ -22,6 +23,7 @@ public class Exhibit {
         this.created = created;
         this.tags = tags;
         this.cover = cover;
+        this.featured = featured;
     }
 
     public Exhibit (ResultSet rs, @SuppressWarnings("unused") int rowNum) throws SQLException {
@@ -32,7 +34,8 @@ public class Exhibit {
                 rs.getString("author"),
                 rs.getTimestamp("created").toInstant(),
                 (String[]) rs.getArray("tags").getArray(),
-                rs.getString("atitle") != null ? Artifact.coverFromJoined(rs) : null
+                rs.getString("atitle") != null ? Artifact.coverFromJoined(rs) : null,
+                rs.getBoolean("featured")
         );
     }
 
@@ -44,7 +47,8 @@ public class Exhibit {
     public Instant getCreated() { return created; }
     public String[] getTags() { return tags; }
     public Artifact getCover() { return cover; }
-    
+    public boolean getFeatured() { return featured; }
+
     public void setId(long id) { this.id = id; }
     public void setTitle(String title) { this.title = title; }
     public void setDescription(String description) { this.description = description; }

--- a/src/main/java/org/comic_conmuseum/fan_forge/backend/models/Exhibit.java
+++ b/src/main/java/org/comic_conmuseum/fan_forge/backend/models/Exhibit.java
@@ -47,7 +47,7 @@ public class Exhibit {
     public Instant getCreated() { return created; }
     public String[] getTags() { return tags; }
     public Artifact getCover() { return cover; }
-    public boolean getFeatured() { return featured; }
+    public boolean isFeatured() { return featured; }
 
     public void setId(long id) { this.id = id; }
     public void setTitle(String title) { this.title = title; }


### PR DESCRIPTION
- feed & detail page have a field, `featured`, which is a boolean representing if the exhibit is featured by the Comic-Con staff.
- when exhibits are created they are not featured
- only admins can feature/un-feature
  - using POST & DELETE /admin/feature/{exhibitID} respectively