### PR TITLE
fix the method on the upvote endpoint

### DIFF
--- a/API_DOCS.md
+++ b/API_DOCS.md
@@ -551,7 +551,7 @@ Delete a comment.
 
 You must be authorized as the author of the comment.
 
-## `POST /support/exhibit/{id}`
+## `PUT /support/exhibit/{id}`
 
 Mark this exhibit as supported by the current user.
 


### PR DESCRIPTION
### What does this PR do?

Fixes a typo in the API docs

### Changelog

Correct mistaken API docs -- they said the endpoint was `POST /support/exhibit/{id}`; it's actually `PUT /support/exhibit/{id}`.