### PR TITLE
More intuitive surveys

### DIFF
--- a/API_DOCS.md
+++ b/API_DOCS.md
@@ -551,9 +551,36 @@ Delete a comment.
 
 You must be authorized as the author of the comment.
 
+## `GET /support/exhibit/{id}`
+
+Get the current user's support survey for the given exhibit.
+
+### Authorization
+
+You must be authorized to hit this endpoint. The user you're authorized as is
+the one whose survey result is returned.
+
+### Response body
+
+```
+{
+  visits: integer // [1-10] How many times the respondent would visit this exhibit
+  rating: integer // [0-10] Rating given by the user, for NPS calculation
+  populations: { // Which populations the respondent thinks would like this
+    // for each of these: `true` means the population would support it
+    male: boolean
+    female: boolean
+    kids: boolean
+    teenagers: boolean
+    adults: boolean
+  }
+}
+```
+
 ## `POST /support/exhibit/{id}`
 
-Mark this exhibit as supported by the current user.
+Mark this exhibit as supported by the current user. If the exhibit is already
+supported, overwrites any provided fields, while leaving the rest the same.
 
 ### Authorization
 

--- a/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/ExhibitSupportEndpoints.java
+++ b/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/ExhibitSupportEndpoints.java
@@ -35,7 +35,7 @@ public class ExhibitSupportEndpoints {
             ));
         }
         for (Survey.Population pop : Survey.Population.values()) {
-            if (!data.getPopulations().containsKey(pop.displayName())) {
+            if (!data.getPopulations().containsKey(pop.display())) {
                 return ResponseEntity.badRequest().body(new ErrorResponse(
                         "Must provide all populations -- see documentation",
                         "Provide all of the populations"

--- a/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/SupportEndpoints.java
+++ b/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/SupportEndpoints.java
@@ -2,6 +2,7 @@ package org.comic_conmuseum.fan_forge.backend.endpoints;
 
 import org.comic_conmuseum.fan_forge.backend.endpoints.inputs.SurveyCreation;
 import org.comic_conmuseum.fan_forge.backend.endpoints.responses.ErrorResponse;
+import org.comic_conmuseum.fan_forge.backend.endpoints.responses.SurveyView;
 import org.comic_conmuseum.fan_forge.backend.models.Survey;
 import org.comic_conmuseum.fan_forge.backend.endpoints.responses.SurveyAggregate;
 import org.comic_conmuseum.fan_forge.backend.persistence.SupportQueryBean;
@@ -15,12 +16,12 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-public class ExhibitSupportEndpoints {
+public class SupportEndpoints {
     private static final Logger LOG = LoggerFactory.getLogger("endpoints.support.exhibit");
     
     private final SupportQueryBean supports;
     
-    public ExhibitSupportEndpoints(SupportQueryBean supportQueryBean) {
+    public SupportEndpoints(SupportQueryBean supportQueryBean) {
         this.supports = supportQueryBean;
     }
     
@@ -62,9 +63,14 @@ public class ExhibitSupportEndpoints {
             return ResponseEntity.badRequest().build();
         }
     }
+    
+    @RequestMapping(value = "/support/exhibit/{id}", method = RequestMethod.GET)
+    public ResponseEntity<SurveyView> getSurvey(@PathVariable long id, @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(new SurveyView(supports.getSupportSurvey(id, user)));
+    }
 
     @RequestMapping(value = "/support/exhibit/{id}", method = RequestMethod.DELETE)
-    public ResponseEntity upvoteExhibit(@PathVariable int id, @AuthenticationPrincipal User user) {
+    public ResponseEntity unsupportExhibit(@PathVariable int id, @AuthenticationPrincipal User user) {
         LOG.info("Unsupporting {} as {}", id, user);
         boolean wasSupporter = supports.deleteSupport(id, user);
         LOG.info("Was a supporter? {}", wasSupporter);
@@ -81,7 +87,7 @@ public class ExhibitSupportEndpoints {
     }
     
     @RequestMapping(value = "/admin/survey-data/{eid}", method = RequestMethod.GET)
-    public ResponseEntity<SurveyAggregate> getAggregate(@PathVariable long eid) {
+    public ResponseEntity<SurveyAggregate> getSurveyAggregate(@PathVariable long eid) {
         return ResponseEntity.ok(supports.getAggregateData(eid));
     }
 }

--- a/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/responses/SurveyView.java
+++ b/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/responses/SurveyView.java
@@ -1,0 +1,17 @@
+package org.comic_conmuseum.fan_forge.backend.endpoints.responses;
+
+import org.comic_conmuseum.fan_forge.backend.models.Survey;
+
+import java.util.Map;
+
+public class SurveyView {
+    public final int visits;
+    public final Map<String, Boolean> populations;
+    public final int rating;
+    
+    public SurveyView(Survey viewOf) {
+        this.visits = viewOf.visits;
+        this.populations = viewOf.populations;
+        this.rating = viewOf.rating;
+    }
+}

--- a/src/main/java/org/comic_conmuseum/fan_forge/backend/models/Survey.java
+++ b/src/main/java/org/comic_conmuseum/fan_forge/backend/models/Survey.java
@@ -15,9 +15,9 @@ public class Survey {
             this.lowercase = this.name().toLowerCase();
         }
 
-        public String displayName() { return lowercase; }
-        public String columnName() { return "pop_" + this.lowercase; }
-        public String sqlParam() { return ":" + columnName(); }
+        public String display() { return lowercase; }
+        public String column() { return "pop_" + this.lowercase; }
+        public String sqlParam() { return ":" + column(); }
 
     }
 
@@ -38,7 +38,7 @@ public class Survey {
         this.visits = rs.getInt("visits");
         this.populations = new HashMap<>();
         for (Population pop : Population.values()) {
-            this.populations.put(pop.displayName(), rs.getBoolean("pop_" + pop));
+            this.populations.put(pop.display(), rs.getBoolean("pop_" + pop));
         }
         this.rating = rs.getInt("rating");
     }


### PR DESCRIPTION
### What does this PR do?

Resolves #57. Changes the way surveys work to better match people's mental model of a survey (as opposed to upvotes)

### Migration

```postgresql
ALTER TABLE supports RENAME CONSTRAINT supports_exhibit_supporter_key TO support_once_per_exhibit;
```

### Changelog

Added `GET /support/exhibit/{id}` endpoint to get the current survey (if any) and changes `PUT /support/exhibit/{id}` endpoint to overwrite old survey instead of erroring out on resubmit.