### PR TITLE
Renamed property, getters/setters and added a convenience

### DIFF
--- a/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/ArtifactEndpoints.java
+++ b/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/ArtifactEndpoints.java
@@ -56,7 +56,11 @@ public class ArtifactEndpoints {
         long id;
         try (TransactionWrapper.Transaction t = transactions.start()) {
             id = artifacts.create(full, data.getParent(), user);
-            MultipartFile file = req.getFile("image");
+            String imageParamName = "image";
+            if (null != data.getImage()) {
+                imageParamName = data.getImage();
+            }
+            MultipartFile file = req.getFile(imageParamName);
             if (file == null) {
                 return ResponseEntity.badRequest().build();
             }

--- a/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/ExhibitEndpoints.java
+++ b/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/ExhibitEndpoints.java
@@ -114,10 +114,10 @@ public class ExhibitEndpoints {
             for (ArtifactCreation a : data.getArtifacts()) {
                 Artifact full = a.build(user);
                 long aid = artifacts.create(full, id, user);
-                if (a.getImageName() == null) {
+                if (a.getImage() == null) {
                     return ResponseEntity.badRequest().build();
                 }
-                MultipartFile file = req.getFile(a.getImageName());
+                MultipartFile file = req.getFile(a.getImage());
                 if (file == null) {
                     return ResponseEntity.badRequest().build();
                 }
@@ -148,8 +148,8 @@ public class ExhibitEndpoints {
                     mentioned.add(a.getId());
                     artifacts.update(a.build(user));
                     // if no image provided, just don't update it!
-                    if (a.getImageName() != null) {
-                        MultipartFile file = req.getFile(a.getImageName());
+                    if (a.getImage() != null) {
+                        MultipartFile file = req.getFile(a.getImage());
                         if (file == null) {
                             return ResponseEntity.badRequest().build();
                         }
@@ -160,10 +160,10 @@ public class ExhibitEndpoints {
                     long aid = artifacts.create(a.build(user), id, user);
                     mentioned.add(aid);
                     // this time an image is required -- you can't have an artifact without one.
-                    if (a.getImageName() == null) {
+                    if (a.getImage() == null) {
                         return ResponseEntity.badRequest().build();
                     }
-                    MultipartFile file = req.getFile(a.getImageName());
+                    MultipartFile file = req.getFile(a.getImage());
                     if (file == null) {
                         return ResponseEntity.badRequest().build();
                     }

--- a/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/inputs/ArtifactCreation.java
+++ b/src/main/java/org/comic_conmuseum/fan_forge/backend/endpoints/inputs/ArtifactCreation.java
@@ -9,21 +9,21 @@ public class ArtifactCreation {
     private Long id;
     private String title;
     private String description;
-    private String imageName;
+    private String image;
     private Long parent;
     private boolean cover;
 
     public Long getId() { return id; }
     public String getTitle() { return title; }
     public String getDescription() { return description; }
-    public String getImageName() { return imageName; }
+    public String getImage() { return image; }
     public Long getParent() { return parent; }
     public boolean isCover() { return cover; }
 
     public void setId(Long id) { this.id = id; }
     public void setTitle(String title) { this.title = title; }
     public void setDescription(String description) { this.description = description; }
-    public void setImageName(String imageName) { this.imageName = imageName; }
+    public void setImage(String image) { this.image = image; }
     public void setParent(Long parent) { this.parent = parent; }
     public void setCover(boolean cover) { this.cover = cover; }
     


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where the expected parameter doesn't match what the docs say it will be.

### Changelog

Correctly look at the `image` property in exhibit uploads, rather than `imageName` (which was erroneous)