### PR TITLE
Raised limits to allow larger images

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,5 +16,5 @@ ff.require-https=true
 spring.datasource.driver=org.postgresql.Driver
 
 # Probably-too-small maximums; they can be bumped up by the user.
-spring.servlet.multipart.max-file-size=64Kb
-spring.servlet.multipart.max-request-size=128Kb
+spring.servlet.multipart.max-file-size=2Mb
+spring.servlet.multipart.max-request-size=4Mb


### PR DESCRIPTION
### What does this PR do?

 - hot fix for allowing to have larger images, which is required to put some nice, high resolution images on the feed / detail for demo

### Migration

None

### Changelog

Raised limit for the file size on upload